### PR TITLE
Enhance FiboProjector adaptive zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
   that instructs `qa_backtest` to run walk-forward optimization and Monte Carlo
   analyses whenever backtesting is requested.
 - Added **RiskManager** library implementing Kelly-based position sizing with stop helpers.
+- `fibo_projector.pine` now supports an adaptive golden zone via the new
+  `useAdaptiveGZ` and `kFactor` parameters and has a demo toggle in
+  `fibo_projector_test.pine`.
 
 ## [v2.0.0] - 2025-06-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,8 +115,16 @@ See `tests/fib_confluence_engine_test.pine` for a minimal runnable script with t
 
 ### `libraries/fibo_projector.pine`
 Computes Fibonacci projection levels from a pivot pair and highlights an adaptive
-*Golden Zone* sized using ATR. The `Projector` type stores levels and offers
-`computeLevels()` and `draw()` helpers.
+*Golden Zone*. The `Projector` type stores levels and offers
+`computeLevels()` and `draw()` helpers. `computeLevels()` now accepts two
+additional parameters:
+
+- `useAdaptiveGZ` – when `true`, the golden zone is centered on the 50% level and
+  sized using `kFactor * ATR`.
+- `kFactor` – multiplier for ATR in the adaptive calculation.
+
+When `useAdaptiveGZ` is `false`, the classic 1.618 projection zone sized by
+`atrMult` remains available.
 
 ### `libraries/fib_bucketing_lib.pine`
 Groups Fibonacci levels into price buckets by rounding to the symbol's minimum tick using a proximity threshold.

--- a/libraries/fibo_projector.pine
+++ b/libraries/fibo_projector.pine
@@ -45,7 +45,15 @@ export newProjector() =>
 // `atrVal` is the current ATR value used to size the golden zone.
 // `atrMult` controls how wide the golden zone is (in ATR multiples).
 // -----------------------------------------------------------------------------
-export method computeLevels(Projector self, float p1, float p2, float atrVal, float atrMult) =>
+export method computeLevels(
+    Projector self,
+    float p1,
+    float p2,
+    float atrVal,
+    float atrMult,
+    bool useAdaptiveGZ,
+    float kFactor
+) =>
     self.isUp := p2 > p1
     float diff = math.abs(p2 - p1)
     array.clear(self.levels)
@@ -53,10 +61,21 @@ export method computeLevels(Projector self, float p1, float p2, float atrVal, fl
         float r = array.get(self.ratios, i)
         float lvl = self.isUp ? p2 + diff * r : p2 - diff * r
         array.push(self.levels, lvl)
-    float gLevel = self.isUp ? p2 + diff * 1.618 : p2 - diff * 1.618
-    float offset = atrVal * atrMult
-    self.lower := gLevel - offset
-    self.upper := gLevel + offset
+
+    if useAdaptiveGZ
+        float Watr = kFactor * atrVal
+        float dRatio = Watr / diff
+        float ratioLo = 0.5 - dRatio
+        float ratioHi = 0.5 + dRatio
+        float lowerRatio = math.max(0.0, ratioLo)
+        float upperRatio = math.min(1.0, ratioHi)
+        self.lower := self.isUp ? p2 + diff * lowerRatio : p2 - diff * lowerRatio
+        self.upper := self.isUp ? p2 + diff * upperRatio : p2 - diff * upperRatio
+    else
+        float gLevel = self.isUp ? p2 + diff * 1.618 : p2 - diff * 1.618
+        float offset = atrVal * atrMult
+        self.lower := gLevel - offset
+        self.upper := gLevel + offset
 
 // -----------------------------------------------------------------------------
 // clearDrawings

--- a/tests/fibo_projector_test.pine
+++ b/tests/fibo_projector_test.pine
@@ -7,12 +7,15 @@ st.Styles styles = st.getStyles()
 fp.Projector proj = fp.newProjector()
 
 float atr = ta.atr(14)
+bool useAdaptive = input.bool(false, 'Adaptive Golden Zone')
+float kFactor    = input.float(0.5, 'k Factor', step=0.1)
+float atrMult    = input.float(1.0, 'ATR Mult', step=0.1)
 
 if barstate.islast
     // Simple demo using the highest/lowest values of the window
     float hi = ta.highest(high, 20)
     float lo = ta.lowest(low, 20)
-    fp.computeLevels(proj, lo, hi, atr, 1.0)
+    fp.computeLevels(proj, lo, hi, atr, atrMult, useAdaptive, kFactor)
     fp.draw(proj, bar_index, bar_index + 20,
             styles.fib_base_color,
             styles.fib_ext_up_col,
@@ -20,3 +23,6 @@ if barstate.islast
             styles.fib_width,
             styles.label_size,
             styles.label_offset)
+
+// Expected output: Fibonacci lines and either a static ATR-based box or a
+// dynamic zone centered on the 50% level when "Adaptive Golden Zone" is enabled.


### PR DESCRIPTION
## Summary
- extend `computeLevels()` with adaptive golden zone logic
- toggle adaptive behaviour in `fibo_projector_test.pine`
- document new parameters for `FiboProjector`
- note the update in `CHANGELOG`

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6858dfa9a29c8320a4789e43802001a4