### PR TITLE
Update StyleLib defaults

### DIFF
--- a/libraries/style_lib.pine
+++ b/libraries/style_lib.pine
@@ -2,19 +2,19 @@
 library("StyleLib", true)
 
 // ---- Support/Resistance zone colors ----
-export const color SR_COLOR_RES    = color.new(color.red, 80)
-export const color SR_COLOR_SUP    = color.new(color.green, 80)
-export const color SR_COLOR_VALID  = color.new(color.orange, 60)
-export const color SR_COLOR_BROKEN = color.new(color.gray, 90)
+export const color SR_COLOR_RES    = color.new(color.red, 92)
+export const color SR_COLOR_SUP    = color.new(color.green, 92)
+export const color SR_COLOR_VALID  = color.new(color.orange, 75)
+export const color SR_COLOR_BROKEN = color.new(color.gray, 95)
 
 // ---- Fibonacci defaults ----
 export const color FIB_BASE_COLOR  = color.new(color.gray, 40)
 export const color FIB_EXT_UP_COL  = color.new(color.green, 0)
 export const color FIB_EXT_DN_COL  = color.new(color.red, 0)
-export const int   FIB_WIDTH       = 2
+export const int   FIB_WIDTH       = 1
 
 // ---- Label and anchor settings ----
-export const string LABEL_SIZE     = "small"
+export const string LABEL_SIZE     = "tiny"
 export const int    LABEL_OFFSET   = 2
 export const string ANCHOR_STYLE   = label.style_label_down
 export const color  ANCHOR_TEXT_COLOR = color.yellow


### PR DESCRIPTION
## Summary
- sync `style_lib.pine` with version from TradingView

## Testing
- `flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_685a2afdf5bc832098a35864dc37dc50