### PR TITLE
Update FibConfluenceEngine imports

### DIFF
--- a/libraries/fib_confluence_engine.pine
+++ b/libraries/fib_confluence_engine.pine
@@ -1,8 +1,8 @@
 //@version=6
 library("FibConfluenceEngine", true)
 
-import "./pivot_utils.pine" as pv
-import "./fib_extension_lib.pine" as fe
+import jonathanmoletta17/PivotUtils/4 as pv
+import jonathanmoletta17/FibExtensionLib/3 as fe
 
 // -----------------------------------------------------------------------------
 //  Swing structure to store pivot pairs
@@ -92,35 +92,37 @@ export getFibLevels(Swing[] swings) =>
 export clusterLevels(float[] levels, float[] weights, float threshold) =>
     Cluster[] clusters = array.new<Cluster>()
     int n = array.size(levels)
+
     if n == 0
-        clusters
+        clusters            // nada a fazer
     else
-        int[] idxs = array.new<int>()
-        for i = 0 to n - 1
-            array.push(idxs, i)
-        // Sort indexes based on their corresponding level values.
-        // Using `array.sort` with a mapping function is supported in
-        // Pine Script v6, while custom comparator functions are not.
-        array.sort(idxs, order.ascending, (i) => array.get(levels, i))
-        float curLow  = array.get(levels, array.get(idxs, 0))
-        float curHigh = curLow
+        // ❶ devolve índices ordenados pelo preço (ascendente por padrão)
+        int[] idxs = array.sort_indices(levels)
+
+        // ❷ percorre esses índices formando os clusters
+        float curLow   = array.get(levels, array.get(idxs, 0))
+        float curHigh  = curLow
         float curScore = array.get(weights, array.get(idxs, 0))
         int   curCount = 1
+
         for k = 1 to n - 1
-            int id = array.get(idxs, k)
+            int   id    = array.get(idxs, k)
             float price = array.get(levels, id)
-            float w = array.get(weights, id)
+            float w     = array.get(weights, id)
+
             if math.abs(price - curHigh) <= threshold
-                curLow  := math.min(curLow, price)
-                curHigh := math.max(curHigh, price)
+                curLow   := math.min(curLow,  price)
+                curHigh  := math.max(curHigh, price)
                 curScore += w
                 curCount += 1
             else
                 array.push(clusters, Cluster.new(curLow, curHigh, curScore / curCount))
-                curLow := price
-                curHigh := price
+                curLow   := price
+                curHigh  := price
                 curScore := w
                 curCount := 1
+
+        // último cluster
         array.push(clusters, Cluster.new(curLow, curHigh, curScore / curCount))
         clusters
 

--- a/libraries/sr_manager_lib.pine
+++ b/libraries/sr_manager_lib.pine
@@ -2,8 +2,8 @@
 
 library("SRManagerLib", true)
 
-import "./sr_zone_utils.pine" as sru
-import "./logistic_model_lib.pine" as lm
+import jonathanmoletta17/SRZoneUtils/4 as sru
+import jonathanmoletta17/LogisticModelLib/5 as lm
 
 // -----------------------------------------------------------------------------
 // createZone

--- a/libraries/style_lib.pine
+++ b/libraries/style_lib.pine
@@ -2,19 +2,19 @@
 library("StyleLib", true)
 
 // ---- Support/Resistance zone colors ----
-export const color SR_COLOR_RES    = color.new(color.red, 80)
-export const color SR_COLOR_SUP    = color.new(color.green, 80)
-export const color SR_COLOR_VALID  = color.new(color.orange, 60)
-export const color SR_COLOR_BROKEN = color.new(color.gray, 90)
+export const color SR_COLOR_RES    = color.new(color.red, 92)
+export const color SR_COLOR_SUP    = color.new(color.green, 92)
+export const color SR_COLOR_VALID  = color.new(color.orange, 75)
+export const color SR_COLOR_BROKEN = color.new(color.gray, 95)
 
 // ---- Fibonacci defaults ----
 export const color FIB_BASE_COLOR  = color.new(color.gray, 40)
 export const color FIB_EXT_UP_COL  = color.new(color.green, 0)
 export const color FIB_EXT_DN_COL  = color.new(color.red, 0)
-export const int   FIB_WIDTH       = 2
+export const int   FIB_WIDTH       = 1
 
 // ---- Label and anchor settings ----
-export const string LABEL_SIZE     = "small"
+export const string LABEL_SIZE     = "tiny"
 export const int    LABEL_OFFSET   = 2
 export const string ANCHOR_STYLE   = label.style_label_down
 export const color  ANCHOR_TEXT_COLOR = color.yellow


### PR DESCRIPTION
## Summary
- use published library imports for FibConfluenceEngine
- sync clustering logic with TradingView version

## Testing
- `flake8` *(fails: E402, E501 across tests and tools)*

------
https://chatgpt.com/codex/tasks/task_e_685a2afdf5bc832098a35864dc37dc50